### PR TITLE
Append queue name to alarm name.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,10 +11,16 @@ class Alarm {
     this.thresholds = alarm.thresholds
   }
 
+  formatAlarmName(value) {
+    // Cloud Watch alarms must be alphanumeric only
+    let queue = this.queue.replace(/[^0-9a-z]/gi, '')
+    return util.format(queue + 'MessageAlarm%s', value)
+  }
+
   ressources () {
     return this.thresholds.map(
       value => ({
-        [util.format('MessageAlarm%s', value)]: {
+        [this.formatAlarmName(value)]: {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
             AlarmDescription: util.format('Alarm if queue contains more than %s messages', value),

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -27,11 +27,48 @@ it('creates CloudFormation configuration', () => {
 
   const data = config.service.provider.compiledCloudFormationTemplate.Resources
 
-  expect(data).toHaveProperty('MessageAlarm3')
-  expect(data).toHaveProperty('MessageAlarm3.Type', 'AWS::CloudWatch::Alarm')
-  expect(data).toHaveProperty('MessageAlarm3.Properties')
-  expect(data).toHaveProperty('MessageAlarm3.Properties.AlarmDescription', 'Alarm if queue contains more than 3 messages')
-  expect(data).toHaveProperty('MessageAlarm3.Properties.Threshold', 3)
+  expect(data).toHaveProperty('testqueueMessageAlarm3')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Type', 'AWS::CloudWatch::Alarm')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.AlarmDescription', 'Alarm if queue contains more than 3 messages')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Threshold', 3)
+})
+
+it('creates alarms for multiple queues', () => {
+    let config = {
+        service: {
+            custom: {
+                'sqs-alarms': [
+                    {
+                        queue: 'test-queue',
+                        topic: 'test-topic',
+                        thresholds: [1,2]
+                    },
+                    {
+                      queue: 'test-queue-2',
+                      topic: 'test-topic',
+                      thresholds: [1, 2]
+                    }
+                ]
+            },
+            provider: {
+                region: 'test-region',
+                compiledCloudFormationTemplate: {
+                    Resources: {}
+                }
+            }
+        }
+    }
+
+    const test = new Plugin(config);
+    test.beforeDeployResources()
+
+    const data = config.service.provider.compiledCloudFormationTemplate.Resources
+
+    expect(data).toHaveProperty('testqueueMessageAlarm1')
+    expect(data).toHaveProperty('testqueueMessageAlarm2')
+    expect(data).toHaveProperty('testqueue2MessageAlarm1')
+    expect(data).toHaveProperty('testqueue2MessageAlarm2')
 })
 
 it('does not fail without configuration', () => {
@@ -51,5 +88,5 @@ it('does not fail without configuration', () => {
 
   const data = config.service.provider.compiledCloudFormationTemplate.Resources
 
-  expect(data).not.toHaveProperty('MessageAlarm3')
+  expect(data).not.toHaveProperty('testqueueMessageAlarm3')
 })


### PR DESCRIPTION
This fixes a bug where queue alarms using the same threshold level
would override previously defined alarms. 

The queue name is added to the alarm name to ensure each alarm name is unique to each queue.