### PR TITLE
Change deploy:compileEvents to package:compileEvents

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -85,7 +85,7 @@ class Plugin {
   constructor (serverless, options) {
     this.serverless = serverless
     this.hooks = {
-      'deploy:compileEvents': this.beforeDeployResources.bind(this)
+      'package:compileEvents': this.beforeDeployResources.bind(this)
     }
   }
 


### PR DESCRIPTION
Event `deploy:compileEvents` is deprecated in favor of `package:compileEvents`. Therefore, this plugin does not work on serverless@1.22.0 and up. For some reason only when using node@8 though.