### PR TITLE
Specify Period and EvaluationPeriods

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -54,7 +54,7 @@ class Alarm {
             Type: 'AWS::CloudWatch::Alarm',
             Properties: {
               AlarmDescription: util.format('Alarm if queue contains more than %s messages', properties.value),
-              Namespace: 'AWS/SQS',
+              Namespace: properties.namespace || 'AWS/SQS',
               MetricName: 'ApproximateNumberOfMessagesVisible',
               Dimensions: [
                 {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -34,14 +34,26 @@ class Alarm {
     }
   }
 
+  resourceProperties (value) {
+    if (value instanceof Object) {
+      return value;
+    }
+
+    return {
+      value
+    }
+  }
+
   ressources () {
     return this.thresholds.map(
-      (value, i) => {
+      (props, i) => {
+        const properties = this.resourceProperties(props);
+
         const config = {
-          [this.formatAlarmName(value)]: {
+          [this.formatAlarmName(properties.value)]: {
             Type: 'AWS::CloudWatch::Alarm',
             Properties: {
-              AlarmDescription: util.format('Alarm if queue contains more than %s messages', value),
+              AlarmDescription: util.format('Alarm if queue contains more than %s messages', properties.value),
               Namespace: 'AWS/SQS',
               MetricName: 'ApproximateNumberOfMessagesVisible',
               Dimensions: [
@@ -51,9 +63,9 @@ class Alarm {
                 }
               ],
               Statistic: 'Sum',
-              Period: 60,
-              EvaluationPeriods: 1,
-              Threshold: value,
+              Period: properties.period || 60,
+              EvaluationPeriods: properties.evaluationPeriods || 1,
+              Threshold: properties.value,
               ComparisonOperator: 'GreaterThanOrEqualToThreshold',
               AlarmActions: [
                 { 'Fn::Join': [ '', [ 'arn:aws:sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
@@ -66,13 +78,13 @@ class Alarm {
         }
 
         if (this.name) {
-          config[this.formatAlarmName(value)].Properties.AlarmName = util.format('%s-%s-%d', this.name, this.queue, value)
+          config[this.formatAlarmName(properties.value)].Properties.AlarmName = util.format('%s-%s-%d', this.name, this.queue, properties.value)
         }
 
         if (this.treatMissingData) {
           let treatMissing = this.resolveTreatMissingData(i)
           if (treatMissing) {
-            config[this.formatAlarmName(value)].Properties.TreatMissingData = treatMissing
+            config[this.formatAlarmName(properties.value)].Properties.TreatMissingData = treatMissing
           }
         }
         return config

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,7 +36,7 @@ class Alarm {
 
   resourceProperties (value) {
     if (value instanceof Object) {
-      return value;
+      return value
     }
 
     return {
@@ -47,7 +47,7 @@ class Alarm {
   ressources () {
     return this.thresholds.map(
       (props, i) => {
-        const properties = this.resourceProperties(props);
+        const properties = this.resourceProperties(props)
 
         const config = {
           [this.formatAlarmName(properties.value)]: {

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -270,7 +270,8 @@ it('creates CloudFormation configuration with custom thresholds', () => {
               {
                 value: 3,
                 period: 5,
-                evaluationPeriods: 1
+                evaluationPeriods: 1,
+                namespace: 'test'
               }
             ]
           }
@@ -296,4 +297,5 @@ it('creates CloudFormation configuration with custom thresholds', () => {
   expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Threshold', 3)
   expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.EvaluationPeriods', 1)
   expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Period', 5)
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Namespace', 'test')
 })

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -246,3 +246,56 @@ describe('alarm treatMissingData', () => {
     })
   })
 })
+
+
+
+it('creates CloudFormation configuration with custom thresholds', () => {
+  let config = {
+    getProvider: () => ({ getRegion: () => 'test-region' }),
+    service: {
+      custom: {
+        'sqs-alarms': [
+          {
+            queue: 'test-queue',
+            topic: 'test-topic',
+            thresholds: [
+              {
+                value: 1,
+                period: 5,
+                evaluationPeriods: 1,
+              }, 
+              {
+                value: 2,
+                period: 5,
+                evaluationPeriods: 1,
+              },
+              {
+                value: 3,
+                period: 5,
+                evaluationPeriods: 1,
+              }
+            ]
+          }
+        ]
+      },
+      provider: {
+        compiledCloudFormationTemplate: {
+          Resources: {}
+        }
+      }
+    }
+  }
+
+  const test = new Plugin(config)
+  test.beforeDeployResources()
+
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources
+
+  expect(data).toHaveProperty('testqueueMessageAlarm3')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Type', 'AWS::CloudWatch::Alarm')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.AlarmDescription', 'Alarm if queue contains more than 3 messages')
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Threshold', 3)
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.EvaluationPeriods', 1)
+  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Period', 5)
+})

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -247,8 +247,6 @@ describe('alarm treatMissingData', () => {
   })
 })
 
-
-
 it('creates CloudFormation configuration with custom thresholds', () => {
   let config = {
     getProvider: () => ({ getRegion: () => 'test-region' }),
@@ -262,17 +260,17 @@ it('creates CloudFormation configuration with custom thresholds', () => {
               {
                 value: 1,
                 period: 5,
-                evaluationPeriods: 1,
-              }, 
+                evaluationPeriods: 1
+              },
               {
                 value: 2,
                 period: 5,
-                evaluationPeriods: 1,
+                evaluationPeriods: 1
               },
               {
                 value: 3,
                 period: 5,
-                evaluationPeriods: 1,
+                evaluationPeriods: 1
               }
             ]
           }


### PR DESCRIPTION
Discussed in #7.

This PR enables the ability to pass an Object as a thresholds value.

This object must contain the `value` key.

Optional keys are: `namespace`, `period`, and `evaluationPeriods`.

# Usage 
```yaml
thresholds:
  - value: 1
    period: 60
    evaluationPeriods: 5
    namespace: My/Namespace

```
as well as
```yaml
thresholds:
  - 1
  - 2
```

This PR includes an additional test to ensure the parameters are correctly set.
"creates CloudFormation configuration with custom thresholds"

