### PR TITLE
add optional description field

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,126 +1,160 @@
-'use strict'
+"use strict";
 
-const _ = require('lodash')
-const util = require('util')
+const _ = require("lodash");
+const util = require("util");
 
 class Alarm {
-  constructor (alarm, region) {
-    this.queue = alarm.queue
-    this.topic = alarm.topic
-    this.region = region
-    this.thresholds = alarm.thresholds
-    this.name = alarm.name
-    this.treatMissingData = alarm.treatMissingData
+  constructor(alarm, region) {
+    this.queue = alarm.queue;
+    this.description = alarm.description;
+    this.topic = alarm.topic;
+    this.region = region;
+    this.thresholds = alarm.thresholds;
+    this.name = alarm.name;
+    this.treatMissingData = alarm.treatMissingData;
   }
 
-  formatAlarmName (value) {
+  formatAlarmName(value) {
     // Cloud Watch alarms must be alphanumeric only
-    let queue = this.queue.replace(/[^0-9a-z]/gi, '')
-    return util.format(queue + 'MessageAlarm%s', value)
+    let queue = this.queue.replace(/[^0-9a-z]/gi, "");
+    return util.format(queue + "MessageAlarm%s", value);
   }
 
-  resolveTreatMissingData (index) {
+  resolveTreatMissingData(index) {
     if (this.treatMissingData.constructor === Array) {
-      return this.validateTreatMissingData(this.treatMissingData[index])
+      return this.validateTreatMissingData(this.treatMissingData[index]);
     } else {
-      return this.validateTreatMissingData(this.treatMissingData)
+      return this.validateTreatMissingData(this.treatMissingData);
     }
   }
 
-  validateTreatMissingData (treatment) {
-    let validTreamtments = ['missing', 'ignore', 'breaching', 'notBreaching']
+  validateTreatMissingData(treatment) {
+    let validTreamtments = ["missing", "ignore", "breaching", "notBreaching"];
     if (validTreamtments.includes(treatment)) {
-      return treatment
+      return treatment;
     }
   }
 
-  resourceProperties (value) {
+  resourceProperties(value) {
     if (value instanceof Object) {
-      return value
+      return value;
     }
 
     return {
       value
-    }
+    };
   }
 
-  ressources () {
-    return this.thresholds.map(
-      (props, i) => {
-        const properties = this.resourceProperties(props)
+  ressources() {
+    return this.thresholds.map((props, i) => {
+      const properties = this.resourceProperties(props);
+      const description = this.description
+        ? this.description
+        : util.format(
+            "Alarm if queue contains more than %s messages",
+            properties.value
+          );
 
-        const config = {
-          [this.formatAlarmName(properties.value)]: {
-            Type: 'AWS::CloudWatch::Alarm',
-            Properties: {
-              AlarmDescription: util.format('Alarm if queue contains more than %s messages', properties.value),
-              Namespace: properties.namespace || 'AWS/SQS',
-              MetricName: 'ApproximateNumberOfMessagesVisible',
-              Dimensions: [
-                {
-                  Name: 'QueueName',
-                  Value: this.queue
-                }
-              ],
-              Statistic: 'Sum',
-              Period: properties.period || 60,
-              EvaluationPeriods: properties.evaluationPeriods || 1,
-              Threshold: properties.value,
-              ComparisonOperator: 'GreaterThanOrEqualToThreshold',
-              AlarmActions: [
-                { 'Fn::Join': [ '', [ 'arn:aws:sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
-              ],
-              OKActions: [
-                { 'Fn::Join': [ '', [ 'arn:aws:sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
-              ]
-            }
+      const config = {
+        [this.formatAlarmName(properties.value)]: {
+          Type: "AWS::CloudWatch::Alarm",
+          Properties: {
+            AlarmDescription: description,
+            Namespace: properties.namespace || "AWS/SQS",
+            MetricName: "ApproximateNumberOfMessagesVisible",
+            Dimensions: [
+              {
+                Name: "QueueName",
+                Value: this.queue
+              }
+            ],
+            Statistic: "Sum",
+            Period: properties.period || 60,
+            EvaluationPeriods: properties.evaluationPeriods || 1,
+            Threshold: properties.value,
+            ComparisonOperator: "GreaterThanOrEqualToThreshold",
+            AlarmActions: [
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sns:" + this.region + ":",
+                    { Ref: "AWS::AccountId" },
+                    ":" + this.topic
+                  ]
+                ]
+              }
+            ],
+            OKActions: [
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sns:" + this.region + ":",
+                    { Ref: "AWS::AccountId" },
+                    ":" + this.topic
+                  ]
+                ]
+              }
+            ]
           }
         }
+      };
 
-        if (this.name) {
-          config[this.formatAlarmName(properties.value)].Properties.AlarmName = util.format('%s-%s-%d', this.name, this.queue, properties.value)
-        }
-
-        if (this.treatMissingData) {
-          let treatMissing = this.resolveTreatMissingData(i)
-          if (treatMissing) {
-            config[this.formatAlarmName(properties.value)].Properties.TreatMissingData = treatMissing
-          }
-        }
-        return config
+      if (this.name) {
+        config[
+          this.formatAlarmName(properties.value)
+        ].Properties.AlarmName = util.format(
+          "%s-%s-%d",
+          this.name,
+          this.queue,
+          properties.value
+        );
       }
-    )
+
+      if (this.treatMissingData) {
+        let treatMissing = this.resolveTreatMissingData(i);
+        if (treatMissing) {
+          config[
+            this.formatAlarmName(properties.value)
+          ].Properties.TreatMissingData = treatMissing;
+        }
+      }
+      return config;
+    });
   }
 }
 
 class Plugin {
-  constructor (serverless, options) {
-    this.serverless = serverless
+  constructor(serverless, options) {
+    this.serverless = serverless;
     this.hooks = {
-      'package:compileEvents': this.beforeDeployResources.bind(this)
-    }
+      "package:compileEvents": this.beforeDeployResources.bind(this)
+    };
   }
 
-  beforeDeployResources () {
-    if (!this.serverless.service.custom || !this.serverless.service.custom['sqs-alarms']) {
-      return
+  beforeDeployResources() {
+    if (
+      !this.serverless.service.custom ||
+      !this.serverless.service.custom["sqs-alarms"]
+    ) {
+      return;
     }
 
-    const alarms = this.serverless.service.custom['sqs-alarms'].map(
-      data => new Alarm(data, this.serverless.getProvider('aws').getRegion())
-    )
+    const alarms = this.serverless.service.custom["sqs-alarms"].map(
+      data => new Alarm(data, this.serverless.getProvider("aws").getRegion())
+    );
 
-    alarms.forEach(
-      alarm => alarm.ressources().forEach(
-        ressource => {
-          _.merge(
-            this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-            ressource
-          )
-        }
-      )
-    )
+    alarms.forEach(alarm =>
+      alarm.ressources().forEach(ressource => {
+        _.merge(
+          this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources,
+          ressource
+        );
+      })
+    );
   }
 }
 
-module.exports = Plugin
+module.exports = Plugin;

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -1,17 +1,14 @@
-'use strict'
+"use strict";
 
-const Plugin = require('../')
+const Plugin = require("../");
 
-it('creates CloudFormation configuration', () => {
+it("creates CloudFormation configuration", () => {
   let config = {
-    getProvider: () => ({ getRegion: () => 'test-region' }),
+    getProvider: () => ({ getRegion: () => "test-region" }),
     service: {
       custom: {
-        'sqs-alarms': [
-          { queue: 'test-queue',
-            topic: 'test-topic',
-            thresholds: [1, 2, 3]
-          }
+        "sqs-alarms": [
+          { queue: "test-queue", topic: "test-topic", thresholds: [1, 2, 3] }
         ]
       },
       provider: {
@@ -20,33 +17,36 @@ it('creates CloudFormation configuration', () => {
         }
       }
     }
-  }
+  };
 
-  const test = new Plugin(config)
-  test.beforeDeployResources()
+  const test = new Plugin(config);
+  test.beforeDeployResources();
 
-  const data = config.service.provider.compiledCloudFormationTemplate.Resources
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources;
 
-  expect(data).toHaveProperty('testqueueMessageAlarm3')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Type', 'AWS::CloudWatch::Alarm')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.AlarmDescription', 'Alarm if queue contains more than 3 messages')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Threshold', 3)
-})
+  expect(data).toHaveProperty("testqueueMessageAlarm3");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Type",
+    "AWS::CloudWatch::Alarm"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.AlarmDescription",
+    "Alarm if queue contains more than 3 messages"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties.Threshold", 3);
+});
 
-describe('alarm name', () => {
-  let config
+describe("alarm name", () => {
+  let config;
 
   beforeEach(() => {
     config = {
-      getProvider: () => ({ getRegion: () => 'test-region' }),
+      getProvider: () => ({ getRegion: () => "test-region" }),
       service: {
         custom: {
-          'sqs-alarms': [
-            { queue: 'test-queue',
-              topic: 'test-topic',
-              thresholds: [1, 2, 3]
-            }
+          "sqs-alarms": [
+            { queue: "test-queue", topic: "test-topic", thresholds: [1, 2, 3] }
           ]
         },
         provider: {
@@ -55,48 +55,55 @@ describe('alarm name', () => {
           }
         }
       }
-    }
-  })
+    };
+  });
 
-  describe('is given', () => {
-    it('adds alarm name to CloudFormation configuration', () => {
-      config.service.custom['sqs-alarms'][0].name = 'alarm'
+  describe("is given", () => {
+    it("adds alarm name to CloudFormation configuration", () => {
+      config.service.custom["sqs-alarms"][0].name = "alarm";
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.AlarmName', 'alarm-test-queue-3')
-    })
-  })
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm3.Properties.AlarmName",
+        "alarm-test-queue-3"
+      );
+    });
+  });
 
-  describe('is not given', () => {
-    it('adds no alarm name to CloudFormation configuration', () => {
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+  describe("is not given", () => {
+    it("adds no alarm name to CloudFormation configuration", () => {
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).not.toHaveProperty('testqueueMessageAlarm3.Properties.AlarmName')
-    })
-  })
-})
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm3.Properties.AlarmName"
+      );
+    });
+  });
+});
 
-it('creates alarms for multiple queues', () => {
+it("creates alarms for multiple queues", () => {
   let config = {
-    getProvider: () => ({ getRegion: () => 'test-region' }),
+    getProvider: () => ({ getRegion: () => "test-region" }),
     service: {
       custom: {
-        'sqs-alarms': [
+        "sqs-alarms": [
           {
-            queue: 'test-queue',
-            topic: 'test-topic',
+            queue: "test-queue",
+            topic: "test-topic",
             thresholds: [1, 2]
           },
           {
-            queue: 'test-queue-2',
-            topic: 'test-topic',
+            queue: "test-queue-2",
+            topic: "test-topic",
             thresholds: [1, 2]
           }
         ]
@@ -107,53 +114,50 @@ it('creates alarms for multiple queues', () => {
         }
       }
     }
-  }
+  };
 
-  const test = new Plugin(config)
-  test.beforeDeployResources()
+  const test = new Plugin(config);
+  test.beforeDeployResources();
 
-  const data = config.service.provider.compiledCloudFormationTemplate.Resources
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources;
 
-  expect(data).toHaveProperty('testqueueMessageAlarm1')
-  expect(data).toHaveProperty('testqueueMessageAlarm2')
-  expect(data).toHaveProperty('testqueue2MessageAlarm1')
-  expect(data).toHaveProperty('testqueue2MessageAlarm2')
-})
+  expect(data).toHaveProperty("testqueueMessageAlarm1");
+  expect(data).toHaveProperty("testqueueMessageAlarm2");
+  expect(data).toHaveProperty("testqueue2MessageAlarm1");
+  expect(data).toHaveProperty("testqueue2MessageAlarm2");
+});
 
-it('does not fail without configuration', () => {
+it("does not fail without configuration", () => {
   let config = {
-    getProvider: () => ({ getRegion: () => 'test-region' }),
+    getProvider: () => ({ getRegion: () => "test-region" }),
     service: {
-      custom: { },
+      custom: {},
       provider: {
         compiledCloudFormationTemplate: {
           Resources: {}
         }
       }
     }
-  }
+  };
 
-  const test = new Plugin(config)
-  test.beforeDeployResources()
+  const test = new Plugin(config);
+  test.beforeDeployResources();
 
-  const data = config.service.provider.compiledCloudFormationTemplate.Resources
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources;
 
-  expect(data).not.toHaveProperty('testqueueMessageAlarm3')
-})
+  expect(data).not.toHaveProperty("testqueueMessageAlarm3");
+});
 
-describe('alarm treatMissingData', () => {
-  let config
+describe("alarm treatMissingData", () => {
+  let config;
 
   beforeEach(() => {
     config = {
-      getProvider: () => ({ getRegion: () => 'test-region' }),
+      getProvider: () => ({ getRegion: () => "test-region" }),
       service: {
         custom: {
-          'sqs-alarms': [
-            { queue: 'test-queue',
-              topic: 'test-topic',
-              thresholds: [1, 2, 3]
-            }
+          "sqs-alarms": [
+            { queue: "test-queue", topic: "test-topic", thresholds: [1, 2, 3] }
           ]
         },
         provider: {
@@ -162,100 +166,159 @@ describe('alarm treatMissingData', () => {
           }
         }
       }
-    }
-  })
+    };
+  });
 
-  describe('is not provided', () => {
-    it('adds alarm without treatMissingData property', () => {
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+  describe("is not provided", () => {
+    it("adds alarm without treatMissingData property", () => {
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
-      expect(data).not.toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData')
-    })
-  })
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData"
+      );
+    });
+  });
 
-  describe('is provided as a string of of a valid type', () => {
-    it('adds alarms with treatMissingData property set to value for all alarms', () => {
-      config.service.custom['sqs-alarms'][0].treatMissingData = 'notBreaching'
+  describe("is provided as a string of of a valid type", () => {
+    it("adds alarms with treatMissingData property set to value for all alarms", () => {
+      config.service.custom["sqs-alarms"][0].treatMissingData = "notBreaching";
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).toHaveProperty('testqueueMessageAlarm1.Properties.TreatMissingData', 'notBreaching')
-      expect(data).toHaveProperty('testqueueMessageAlarm2.Properties.TreatMissingData', 'notBreaching')
-      expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData', 'notBreaching')
-    })
-  })
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm1.Properties.TreatMissingData",
+        "notBreaching"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm2.Properties.TreatMissingData",
+        "notBreaching"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData",
+        "notBreaching"
+      );
+    });
+  });
 
-  describe('is provided as a string an invalid type', () => {
-    it('adds alarms with treatMissingData property set to value for all alarms', () => {
-      config.service.custom['sqs-alarms'][0].treatMissingData = 'invalid'
+  describe("is provided as a string an invalid type", () => {
+    it("adds alarms with treatMissingData property set to value for all alarms", () => {
+      config.service.custom["sqs-alarms"][0].treatMissingData = "invalid";
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).not.toHaveProperty('testqueueMessageAlarm1.Properties.TreatMissingData')
-      expect(data).not.toHaveProperty('testqueueMessageAlarm2.Properties.TreatMissingData')
-      expect(data).not.toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData')
-    })
-  })
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm1.Properties.TreatMissingData"
+      );
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm2.Properties.TreatMissingData"
+      );
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData"
+      );
+    });
+  });
 
-  describe('is provided as an array of strings of valid types', () => {
-    it('adds alarms with treatMissingData property set to corresponding value', () => {
-      config.service.custom['sqs-alarms'][0].treatMissingData = ['notBreaching', 'breaching', 'ignore']
+  describe("is provided as an array of strings of valid types", () => {
+    it("adds alarms with treatMissingData property set to corresponding value", () => {
+      config.service.custom["sqs-alarms"][0].treatMissingData = [
+        "notBreaching",
+        "breaching",
+        "ignore"
+      ];
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).toHaveProperty('testqueueMessageAlarm1.Properties.TreatMissingData', 'notBreaching')
-      expect(data).toHaveProperty('testqueueMessageAlarm2.Properties.TreatMissingData', 'breaching')
-      expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData', 'ignore')
-    })
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm1.Properties.TreatMissingData",
+        "notBreaching"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm2.Properties.TreatMissingData",
+        "breaching"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData",
+        "ignore"
+      );
+    });
 
-    it('adds alarms with treatMissingData to only the alarms with matching index', () => {
-      config.service.custom['sqs-alarms'][0].treatMissingData = ['notBreaching', 'breaching']
+    it("adds alarms with treatMissingData to only the alarms with matching index", () => {
+      config.service.custom["sqs-alarms"][0].treatMissingData = [
+        "notBreaching",
+        "breaching"
+      ];
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).toHaveProperty('testqueueMessageAlarm1.Properties.TreatMissingData', 'notBreaching')
-      expect(data).toHaveProperty('testqueueMessageAlarm2.Properties.TreatMissingData', 'breaching')
-      expect(data).not.toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData')
-    })
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm1.Properties.TreatMissingData",
+        "notBreaching"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm2.Properties.TreatMissingData",
+        "breaching"
+      );
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData"
+      );
+    });
 
-    it('adds alarms with treatMissingData ignoring ivalid types', () => {
-      config.service.custom['sqs-alarms'][0].treatMissingData = ['notBreaching', 'invalid', 'missing']
+    it("adds alarms with treatMissingData ignoring ivalid types", () => {
+      config.service.custom["sqs-alarms"][0].treatMissingData = [
+        "notBreaching",
+        "invalid",
+        "missing"
+      ];
 
-      const test = new Plugin(config)
-      test.beforeDeployResources()
+      const test = new Plugin(config);
+      test.beforeDeployResources();
 
-      const data = config.service.provider.compiledCloudFormationTemplate.Resources
+      const data =
+        config.service.provider.compiledCloudFormationTemplate.Resources;
 
-      expect(data).toHaveProperty('testqueueMessageAlarm1.Properties.TreatMissingData', 'notBreaching')
-      expect(data).not.toHaveProperty('testqueueMessageAlarm2.Properties.TreatMissingData')
-      expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.TreatMissingData', 'missing')
-    })
-  })
-})
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm1.Properties.TreatMissingData",
+        "notBreaching"
+      );
+      expect(data).not.toHaveProperty(
+        "testqueueMessageAlarm2.Properties.TreatMissingData"
+      );
+      expect(data).toHaveProperty(
+        "testqueueMessageAlarm3.Properties.TreatMissingData",
+        "missing"
+      );
+    });
+  });
+});
 
-it('creates CloudFormation configuration with custom thresholds', () => {
+it("creates CloudFormation configuration with custom thresholds", () => {
   let config = {
-    getProvider: () => ({ getRegion: () => 'test-region' }),
+    getProvider: () => ({ getRegion: () => "test-region" }),
     service: {
       custom: {
-        'sqs-alarms': [
+        "sqs-alarms": [
           {
-            queue: 'test-queue',
-            topic: 'test-topic',
+            queue: "test-queue",
+            topic: "test-topic",
             thresholds: [
               {
                 value: 1,
@@ -271,7 +334,7 @@ it('creates CloudFormation configuration with custom thresholds', () => {
                 value: 3,
                 period: 5,
                 evaluationPeriods: 1,
-                namespace: 'test'
+                namespace: "test"
               }
             ]
           }
@@ -283,19 +346,97 @@ it('creates CloudFormation configuration with custom thresholds', () => {
         }
       }
     }
-  }
+  };
 
-  const test = new Plugin(config)
-  test.beforeDeployResources()
+  const test = new Plugin(config);
+  test.beforeDeployResources();
 
-  const data = config.service.provider.compiledCloudFormationTemplate.Resources
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources;
 
-  expect(data).toHaveProperty('testqueueMessageAlarm3')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Type', 'AWS::CloudWatch::Alarm')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.AlarmDescription', 'Alarm if queue contains more than 3 messages')
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Threshold', 3)
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.EvaluationPeriods', 1)
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Period', 5)
-  expect(data).toHaveProperty('testqueueMessageAlarm3.Properties.Namespace', 'test')
-})
+  expect(data).toHaveProperty("testqueueMessageAlarm3");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Type",
+    "AWS::CloudWatch::Alarm"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.AlarmDescription",
+    "Alarm if queue contains more than 3 messages"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties.Threshold", 3);
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.EvaluationPeriods",
+    1
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties.Period", 5);
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.Namespace",
+    "test"
+  );
+});
+
+it("creates CloudFormation configuration with custom thresholds", () => {
+  let config = {
+    getProvider: () => ({ getRegion: () => "test-region" }),
+    service: {
+      custom: {
+        "sqs-alarms": [
+          {
+            queue: "test-queue",
+            topic: "test-topic",
+            description: "some-description",
+            thresholds: [
+              {
+                value: 1,
+                period: 5,
+                evaluationPeriods: 1
+              },
+              {
+                value: 2,
+                period: 5,
+                evaluationPeriods: 1
+              },
+              {
+                value: 3,
+                period: 5,
+                evaluationPeriods: 1,
+                namespace: "test"
+              }
+            ]
+          }
+        ]
+      },
+      provider: {
+        compiledCloudFormationTemplate: {
+          Resources: {}
+        }
+      }
+    }
+  };
+
+  const test = new Plugin(config);
+  test.beforeDeployResources();
+
+  const data = config.service.provider.compiledCloudFormationTemplate.Resources;
+
+  expect(data).toHaveProperty("testqueueMessageAlarm3");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Type",
+    "AWS::CloudWatch::Alarm"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties");
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.AlarmDescription",
+    "some-description"
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties.Threshold", 3);
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.EvaluationPeriods",
+    1
+  );
+  expect(data).toHaveProperty("testqueueMessageAlarm3.Properties.Period", 5);
+  expect(data).toHaveProperty(
+    "testqueueMessageAlarm3.Properties.Namespace",
+    "test"
+  );
+});


### PR DESCRIPTION
Our monitoring system requires alarm description fields to be customized so we can break down by application, stage,etc.  The current description field is static and valuable, but this might provide more flexibility to the plugin. 
Unit test added to show the expected behaviour 