### PR TITLE
use partition pseudo variable for compatibility with gov-cloud

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,10 +68,10 @@ class Alarm {
               Threshold: properties.value,
               ComparisonOperator: 'GreaterThanOrEqualToThreshold',
               AlarmActions: [
-                { 'Fn::Join': [ '', [ 'arn:aws:sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
+                { 'Fn::Join': [ '', [ 'arn:', { 'Ref': 'AWS::Partition' }, ':sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
               ],
               OKActions: [
-                { 'Fn::Join': [ '', [ 'arn:aws:sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
+                { 'Fn::Join': [ '', [ 'arn:', { 'Ref': 'AWS::Partition' }, ':sns:' + this.region + ':', { 'Ref': 'AWS::AccountId' }, ':' + this.topic ] ] }
               ]
             }
           }


### PR DESCRIPTION
When deploying into AWS GovCloud, the ARN uses a different partition value. I believe this is also true for china regions as well. 
When trying to create alarm resources, cloudformation update will fail with one of the event errors being:

```
Invalid partition aws specified. Only aws-us-gov is supported. (Service: AmazonCloudWatch; Status Code: 400; Error Code: ValidationError; Request ID: 50120a93-12b8-40cb-bd3b-65266f0491f9; Proxy: null)
```

In order to accommodate deployments to these special regions you should use the `AWS::Partition` cloud formation pseudo parameters instead. The appropriate value will be filled in.

Before the change:
```
"AlarmActions": [
          {
            "Fn::Join": [
              "",
              [
                "arn:aws:sns:us-gov-east-1:",
                {
                  "Ref": "AWS::AccountId"
                },
                ":undefined"
              ]
            ]
          }
        ],
```
After the change
```
"AlarmActions": [
          {
            "Fn::Join": [
              "",
              [
                "arn:", 
               {
                  "Ref": "AWS::Partition"
                },
                ,":sns:us-gov-east-1:",
                {
                  "Ref": "AWS::AccountId"
                },
                ":undefined"
              ]
            ]
          }
        ],
```